### PR TITLE
Read api key from .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Then add the facade to your `aliases` array:
 
 Finally, publish the config file with `php artisan vendor:publish`or`php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel5"`.You'll find it at `config/kavenegar.php`.
 
+You can also set `KAVENEGAR_API_KEY` in your `.env` file.
+
 ## Laravel 4
 
 Add the `Kavenegar\Laravel\ServiceProvider` provider to the `providers` array in `app/config.php`:

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,4 +1,4 @@
 <?php 
 return [
-    'apikey' => '',
+    'apikey' => env('KAVENEGAR_API_KEY'),
 ];


### PR DESCRIPTION
Users can set `KAVENEGAR_API_KEY` in `.env` file now.