### PR TITLE
Laravel 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install it this way :
 composer require kavenegar/laravel
 ```
 
-## Laravel 6
+## Laravel 5 and 6
 
 Add the `Kavenegar\Laravel\ServiceProvider` provider to the `providers` array in `config/app.php`:
 
@@ -43,29 +43,10 @@ Then add the facade to your `aliases` array:
 ],
 ```
 
-Finally, publish the config file with `php artisan vendor:publish`or`php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel6"`.You'll find it at `config/kavenegar.php`.
-
-## Laravel 5
-
-Add the `Kavenegar\Laravel\ServiceProvider` provider to the `providers` array in `config/app.php`:
-
-```php
-'providers' => [
-  ...
-  Kavenegar\Laravel\ServiceProvider::class,
-],
-```
-
-Then add the facade to your `aliases` array:
-
-```php
-'aliases' => [
-  ...
-  'Kavenegar' => Kavenegar\Laravel\Facade::class,
-],
-```
-
-Finally, publish the config file with `php artisan vendor:publish`or`php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel5"`.You'll find it at `config/kavenegar.php`.
+Finally, publish the config file with `php artisan vendor:publish`
+Or alternatively for laravel 5 you can do: `php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel5"`.
+And for laravel 6: `php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel6"`.
+And you'll find it at `config/kavenegar.php`.
 
 ## Laravel 4
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # kavenegar-laravel
 
 # <a href="http://kavenegar.com/rest.html">Kavenegar RESTful API Document</a>
-If you need to future information about API document Please visit RESTful Document
 
+If you need to future information about API document Please visit RESTful Document
 
 ## Requirements
 
@@ -17,11 +17,33 @@ First of all, You need to make an account on Kavenegar from <a href="https://pan
 After that you just need to pick API-KEY up from <a href="http://panel.kavenegar.com/Client/setting/index">My Account</a> section.
 </p>
 
-Install it this way : 
+Install it this way :
 
 ```sh
 composer require kavenegar/laravel
 ```
+
+## Laravel 6
+
+Add the `Kavenegar\Laravel\ServiceProvider` provider to the `providers` array in `config/app.php`:
+
+```php
+'providers' => [
+  ...
+  Kavenegar\Laravel\ServiceProvider::class,
+],
+```
+
+Then add the facade to your `aliases` array:
+
+```php
+'aliases' => [
+  ...
+  'Kavenegar' => Kavenegar\Laravel\Facade::class,
+],
+```
+
+Finally, publish the config file with `php artisan vendor:publish`or`php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel6"`.You'll find it at `config/kavenegar.php`.
 
 ## Laravel 5
 
@@ -67,9 +89,8 @@ Then add the facade to your `aliases` array:
 
 Finally, publish the config file with `php artisan config:publish kavenegar/laravel`. You'll find the config file at `app/config/packages/kavenegar/laravel/config.php`.
 
-
-
 ## Usage
+
 Well, There is an example to Send SMS by Laravel below.
 
 ```php
@@ -90,7 +111,7 @@ try{
             echo "receptor = $r->receptor";
             echo "date = $r->date";
             echo "cost = $r->cost";
-        }       
+        }
     }
 }
 catch(\Kavenegar\Exceptions\ApiException $e){
@@ -110,7 +131,7 @@ sample output
         "status":200,
         "message":"تایید شد"
     },
-    "entries": 
+    "entries":
     [
         {
             "messageid":8792343,
@@ -136,8 +157,10 @@ sample output
 }
 */
 ```
+
 #Contribution
 Bug fixes, docs, and enhancements welcome! Please let us know <a href="mailto:support@kavenegar.com?Subject=SDK" target="_top">support@kavenegar.com</a>
+
 <hr>
 <div dir='rtl'>
 	
@@ -149,30 +172,29 @@ Bug fixes, docs, and enhancements welcome! Please let us know <a href="mailto:su
 
 ### ساخت حساب کاربری
 
-اگر در وب سرویس کاوه نگار عضو نیستید میتوانید از [لینک عضویت](http://panel.kavenegar.com/client/membership/register) ثبت نام  و اکانت آزمایشی برای تست API دریافت نمایید.
+اگر در وب سرویس کاوه نگار عضو نیستید میتوانید از [لینک عضویت](http://panel.kavenegar.com/client/membership/register) ثبت نام و اکانت آزمایشی برای تست API دریافت نمایید.
 
 ### مستندات
 
-برای مشاهده اطلاعات کامل مستندات [وب سرویس پیامک](http://kavenegar.com/وب-سرویس-پیامک.html)  به صفحه [مستندات وب سرویس](http://kavenegar.com/rest.html) مراجعه نمایید.
+برای مشاهده اطلاعات کامل مستندات [وب سرویس پیامک](http://kavenegar.com/وب-سرویس-پیامک.html) به صفحه [مستندات وب سرویس](http://kavenegar.com/rest.html) مراجعه نمایید.
 
 ### راهنمای فارسی
 
 در صورتی که مایل هستید راهنمای فارسی کیت توسعه کاوه نگار را مطالعه کنید به صفحه [کد ارسال پیامک](http://kavenegar.com/sdk.html) مراجعه نمایید.
 
 ### اطالاعات بیشتر
+
 برای مطالعه بیشتر به صفحه معرفی
 [وب سرویس اس ام اس ](http://kavenegar.com)
 کاوه نگار
 مراجعه نمایید .
 
- اگر در استفاده از کیت های سرویس کاوه نگار مشکلی یا پیشنهادی  داشتید ما را با یک Pull Request  یا  ارسال ایمیل به support@kavenegar.com  خوشحال کنید.
- 
-##
-![http://kavenegar.com](http://kavenegar.com/public/images/logo.png)		
+اگر در استفاده از کیت های سرویس کاوه نگار مشکلی یا پیشنهادی داشتید ما را با یک Pull Request یا ارسال ایمیل به support@kavenegar.com خوشحال کنید.
 
-[http://kavenegar.com](http://kavenegar.com)	
+##
+
+![http://kavenegar.com](http://kavenegar.com/public/images/logo.png)
+
+[http://kavenegar.com](http://kavenegar.com)
 
 </div>
-
-
-

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ Then add the facade to your `aliases` array:
 ```
 
 Finally, publish the config file with `php artisan vendor:publish`
+&nbsp;
 Or alternatively for laravel 5 you can do: `php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel5"`.
-And for laravel 6: `php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel6"`.
+&nbsp;
+And for laravel 6: `php artisan vendor:publish --provider="Kavenegar\Laravel\ServiceProviderLaravel6"`.<br />
+&nbsp;
 And you'll find it at `config/kavenegar.php`.
 
 ## Laravel 4

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -66,13 +66,15 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
         switch ($version) {
             case 4:
-              return new ServiceProviderLaravel4($app);
+                return new ServiceProviderLaravel4($app);
 
             case 5:
-              return new ServiceProviderLaravel5($app);
+                return new ServiceProviderLaravel5($app);
 
+            case 6:
+                return new ServiceProviderLaravel6($app);
             default:
-              throw new RuntimeException('Your version of Laravel is not supported');
+                throw new RuntimeException('Your version of Laravel is not supported');
         }
     }
 

--- a/src/ServiceProviderLaravel6.php
+++ b/src/ServiceProviderLaravel6.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kavenegar\Laravel;
+
+use Kavenegar\KavenegarApi as KavenegarApi;
+
+class ServiceProviderLaravel6 extends \Illuminate\Support\ServiceProvider
+{
+    /**
+     * Bootstrap the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([__DIR__ . '/config/config.php' => config_path('kavenegar.php')]);
+    }
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__ . '/config/config.php', 'kavenegar');
+        $this->app->singleton('kavenegar', function ($app) {
+            return new KavenegarApi($app['config']->get('kavenegar.apikey'));
+        });
+    }
+}


### PR DESCRIPTION
After the release of Laravel 6, this package became obsolete. When trying to publish the ServiceProvider, we would get an error that said "Your version of Laravel is not supported".
So I decided to fix the issue. With a little customization, the package is now available on Laravel 6.
![Selection_799](https://user-images.githubusercontent.com/3878847/64607909-b4247780-d3de-11e9-85ac-200b22b9c6fd.png)
