### PR TITLE
update doc block for static analyzer fix

### DIFF
--- a/src/Notification/KavenegarBaseNotification.php
+++ b/src/Notification/KavenegarBaseNotification.php
@@ -27,7 +27,7 @@ class KavenegarBaseNotification extends Notification
      * Get the mail representation of the notification.
      *
      * @param mixed $notifiable
-     * @return \Illuminate\Notifications\Messages\MailMessage
+     * @return \Kavenegar\Laravel\Message\KavenegarMessage
      */
     public function toKavenegar($notifiable)
     {


### PR DESCRIPTION
if you use static analyzer like larastan with kavenegar will give you an error like this 
```php
Method App\Notifications\VerifySMSNotification::toKavenegar() should  
         return Illuminate\Notifications\Messages\MailMessage but returns      
         Kavenegar\Laravel\Message\KavenegarMessage.
```