### PR TITLE
Remove the mandatory parameter which is optional

### DIFF
--- a/src/Channel/KavenegarChannel.php
+++ b/src/Channel/KavenegarChannel.php
@@ -47,7 +47,7 @@ class KavenegarChannel
         $message = $notification->toKavenegar($notifiable);
 
         $message->to($message->to ?: $notifiable->routeNotificationFor('kavenegar', $notification));
-        if (!$message->to || !($message->from || $message->method)) {
+        if (!$message->to || !$message->method) {
             return;
         }
 


### PR DESCRIPTION
Sender number or `$message->from` is an optional parameter to Kavenegar api